### PR TITLE
ci: fixed @semantic-release/commit-analyzer config

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,24 +73,29 @@
       [
         "@semantic-release/commit-analyzer",
         {
-          "type": "docs",
-          "release": "patch"
-        },
-        {
-          "type": "test",
-          "release": "patch"
-        },
-        {
-          "type": "ci",
-          "release": "patch"
-        },
-        {
-          "type": "refactor",
-          "release": "patch"
-        },
-        {
-          "scope": "no-release",
-          "release": false
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "ci",
+              "release": "patch"
+            },
+            {
+              "type": "refactor",
+              "release": "patch"
+            },
+            {
+              "scope": "no-release",
+              "release": false
+            }
+          ]
         }
       ],
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
CI job triggered in the github action has been failed due to the wrong @semantic-release/commit-analyzer configutaion. It should be fixed by this PR.